### PR TITLE
Implements new ProDuSe filters

### DIFF
--- a/ProDuSe/ProdusePipeline.py
+++ b/ProDuSe/ProdusePipeline.py
@@ -251,6 +251,8 @@ snvArgs.add_argument(
 
 # Filter Args
 filterArgs = parser.add_argument_group("Filter Arguments")
+filterArgs.add_argument("-ss", "--allow_single_stranded", action="store_true", default=False, help="Allow variants with only single stranded support")
+"""
 filterArgs.add_argument("-dsv", "--totalvaf", type=float, default=0.05, help="Dual-strand VAF threshold [Default: %(default)s]")
 filterArgs.add_argument("-md", "--min_duplex", type=int, default=3, help="Minimum duplex support required to call a variant [Default: %(default)s]")
 filterArgs.add_argument("-mp", "--min_pos_strand", type=int, default=1, help="Minimum positive strand support required to call a varaint [Default: %(default)s]")
@@ -258,7 +260,7 @@ filterArgs.add_argument("-mn", "--min_neg_strand", type=int, default=1, help="Mi
 filterArgs.add_argument("-ms", "--min_singleton", type=int, default=3, help="Minimum singleton support required to call a variant [Default: %(default)s]")
 filterArgs.add_argument("-ww", "--weak_base_weight", type=lambda x: isValidWeight(x, parser), default=0.1, help="Weight of weak bases, relative to strong supported bases [Default: %(default)s]")
 filterArgs.add_argument("-sb", "--strand_bias", type=float, default=0.05, help="Strand bias p-value threshold, below which variants will be ignored")
-
+"""
 
 
 def isValidFile(file, parser):
@@ -525,10 +527,7 @@ def runPipeline(args, sampleName, sampleDir):
 	sys.stderr.write("\t".join([printPrefix, time.strftime('%X'), sampleName + ": SNV Calling Complete\n"]))
 
 	# Filter variants
-	vcfFile = os.path.join(sampleDir, "results", sampleName + ".variants.vcf")
-	outFile = vcfFile.replace(".vcf", ".filtered.vcf")
-	args.input=vcfFile
-	args.output=outFile
+	args.config = getConfig(sampleDir, "filter")
 	filter_produse.main(args)
 	# runFilter(args.vaf, vcfFile, scriptDir + os.sep + "filter_produse.pl")
 	sys.stderr.write("\t".join([printPrefix, time.strftime('%X'), sampleName + ": Variant Filtering Complete\n"]))

--- a/ProDuSe/ProdusePipeline.py
+++ b/ProDuSe/ProdusePipeline.py
@@ -255,6 +255,7 @@ filterArgs.add_argument("-ss", "--allow_single_stranded", action="store_true", d
 filterArgs.add_argument("-sb", "--strand_bias_threshold", default=0.05, type=float, help="Strand bias p-value threshold, below which vairants will be discarded [Default: %(default)s]")
 filterArgs.add_argument("-st", "--strong_base_threshold", default=1, type=int, help="Strong supported base count threshold [Default: %(default)s]")
 filterArgs.add_argument("-wt", "--weak_base_threshold", default=2, type=int, help="Weak supported base count theshold [Default: %(default)s]")
+filterArgs.add_argument("-md", "--min_depth", type=int, default=2, help="Minimum depth threshold [Default: %(default)s]")
 """
 filterArgs.add_argument("-dsv", "--totalvaf", type=float, default=0.05, help="Dual-strand VAF threshold [Default: %(default)s]")
 filterArgs.add_argument("-md", "--min_duplex", type=int, default=3, help="Minimum duplex support required to call a variant [Default: %(default)s]")

--- a/ProDuSe/ProdusePipeline.py
+++ b/ProDuSe/ProdusePipeline.py
@@ -251,8 +251,10 @@ snvArgs.add_argument(
 
 # Filter Args
 filterArgs = parser.add_argument_group("Filter Arguments")
-filterArgs.add_argument("-ss", "--allow_single_stranded", action="store_true", default=False, help="Allow variants with only single stranded support")
-filterArgs.add_argument("-sb", "--strand_bias_threshold", default=0.05, type=int, help="Strand bias p-value threshold, below which vairants will be discarded")
+filterArgs.add_argument("-ss", "--allow_single_stranded", action="store_true", default=False, help="Allow variants with only single stranded support [Default: %(default)s]")
+filterArgs.add_argument("-sb", "--strand_bias_threshold", default=0.05, type=float, help="Strand bias p-value threshold, below which vairants will be discarded [Default: %(default)s]")
+filterArgs.add_argument("-st", "--strong_base_threshold", default=1, type=int, help="Strong supported base count threshold [Default: %(default)s]")
+filterArgs.add_argument("-wt", "--weak_base_threshold", default=2, type=int, help="Weak supported base count theshold [Default: %(default)s]")
 """
 filterArgs.add_argument("-dsv", "--totalvaf", type=float, default=0.05, help="Dual-strand VAF threshold [Default: %(default)s]")
 filterArgs.add_argument("-md", "--min_duplex", type=int, default=3, help="Minimum duplex support required to call a variant [Default: %(default)s]")

--- a/ProDuSe/ProdusePipeline.py
+++ b/ProDuSe/ProdusePipeline.py
@@ -245,13 +245,14 @@ snvArgs.add_argument(
     )
 snvArgs.add_argument(
     "-mq", "--min_qual",
-    default=3,
+    default=30,
     type=int,
-    help="Minimum base quality threshold, below which a base will be treated as \'N\'")
+    help="Minimum base quality threshold, below which a WEAK base will be ignored'")
 
 # Filter Args
 filterArgs = parser.add_argument_group("Filter Arguments")
 filterArgs.add_argument("-ss", "--allow_single_stranded", action="store_true", default=False, help="Allow variants with only single stranded support")
+filterArgs.add_argument("-sb", "--strand_bias_threshold", default=0.05, type=int, help="Strand bias p-value threshold, below which vairants will be discarded")
 """
 filterArgs.add_argument("-dsv", "--totalvaf", type=float, default=0.05, help="Dual-strand VAF threshold [Default: %(default)s]")
 filterArgs.add_argument("-md", "--min_duplex", type=int, default=3, help="Minimum duplex support required to call a variant [Default: %(default)s]")

--- a/ProDuSe/SplitMerge.py
+++ b/ProDuSe/SplitMerge.py
@@ -458,7 +458,7 @@ def getCigarSeq(subCig, template, origCigList, sequence):
 	Returns:
 		offset: The offset of this sub-cigar from the start of the cigar (int)
 		cigOutList: The sequence of the original cigar represented by the sub-cigar (list)
-		outSequence: The nucleotide sequence represented by the sub-cigar sequence (string) 
+		outSequence: The nucleotide sequence represented by the sub-cigar sequence (string)
 	"""
 	if subCig is None:
 		return None, None, ""
@@ -811,6 +811,10 @@ def processRead(read, origReads, counter):
 			fStart = getStartIndex(read.reference_start, sepReads["fCigarList"], origReads[0].cigarstring)
 			rRead = createRead(read, origReads[1].flag, sepReads["rOffset"], sepReads["rOffset"] + len(sepReads["rSeq"]), origReads[1].template_length, listToCigar(sepReads["rCigarList"]), fStart, rStart)
 			fRead = createRead(read, origReads[0].flag, 0, len(sepReads["fSeq"]), origReads[0].template_length, listToCigar(sepReads["fCigarList"]), rStart, fStart)
+		else:
+			# Something awful has happened here. I'm not even sure how this is possible, but it does occur *very* rarely in some samples
+			# TODO: Figure out what is going on here. For now, I am just going to discard these reads
+			return []
 
 		return [fRead, rRead]
 

--- a/ProDuSe/configure_produse.py
+++ b/ProDuSe/configure_produse.py
@@ -181,18 +181,35 @@ def make_directory(sample_dir, fastqs, sampleConfig, pconfig, reference, sample_
     new_config.write(output)
     output.close()
 
+    # SNV files
+    snv_vcf_results = results_dir + os.sep + sample_name + "variants.vcf"
+    snv_stats_data = data_dir + os.sep + sample_name + "Molecule_Counts.txt"
+
     # Creates SNV calling config file
     new_config = configparser.RawConfigParser()
     new_config.add_section("config")
     new_config.set("config", "input", results_dir + os.sep + sample_name + "SplitMerge.sorted.bam")
-    new_config.set("config", "molecule_stats", data_dir + os.sep + sample_name + "Molecule_Counts.txt")
-    new_config.set("config", "output", os.sep.join([results_dir, sample_name + "variants.vcf"]))
+    new_config.set("config", "molecule_stats", snv_stats_data)
+    new_config.set("config", "output", snv_vcf_results)
     new_config.set("config", "reference", reference)
     for (key, val) in cparser.items("snv"):
         new_config.set("config", key, val)
         if key in sampleConfig:
             val = sampleConfig[key]
     output = open(os.sep.join([sample_dir, "config", os.sep, "snv_task.ini"]), 'w')
+    new_config.write(output)
+
+    # Creates Filter config file
+    new_config = configparser.RawConfigParser()
+    new_config.add_section("config")
+    new_config.set("config", "input", snv_vcf_results)
+    new_config.set("config", "molecule_stats", snv_stats_data)
+    new_config.set("config", "output", snv_vcf_results.replace(".vcf", ".filtered.vcf"))
+    for (key, val) in cparser.items("filter_produse"):
+        new_config.set("config", key, val)
+        if key in sampleConfig:
+            val = sampleConfig[key]
+    output = open(os.sep.join([sample_dir, "config", os.sep, "filter_task.ini"]), 'w')
     new_config.write(output)
 
 

--- a/ProDuSe/configure_produse.py
+++ b/ProDuSe/configure_produse.py
@@ -185,6 +185,7 @@ def make_directory(sample_dir, fastqs, sampleConfig, pconfig, reference, sample_
     new_config = configparser.RawConfigParser()
     new_config.add_section("config")
     new_config.set("config", "input", results_dir + os.sep + sample_name + "SplitMerge.sorted.bam")
+    new_config.set("config", "molecule_stats", data_dir + os.sep + sample_name + "Molecule_Counts.txt")
     new_config.set("config", "output", os.sep.join([results_dir, sample_name + "variants.vcf"]))
     new_config.set("config", "reference", reference)
     for (key, val) in cparser.items("snv"):

--- a/ProDuSe/filter_produse.py
+++ b/ProDuSe/filter_produse.py
@@ -200,7 +200,7 @@ def runFilter(vcfFile, thresholds, outFile, minDepth=0, strandBiasThresh=0.05, a
 			infoFields = processFields(infoCol)
 
 			# Filter for minimum depth
-			totalDepth = sum(int(infoFields["MC"][x] for x in range(0, 4)))
+			totalDepth = sum(int(infoFields["MC"][x]) for x in range(0, 4))
 			if totalDepth < minDepth:
 				continue
 

--- a/ProDuSe/filter_produse.py
+++ b/ProDuSe/filter_produse.py
@@ -252,7 +252,14 @@ def runFilter(vcfFile, thresholds, outFile, strandBiasThresh=0.05, allow_single=
 						passingAltAlleles.append(allele)
 
 			if passingAltAlleles:
-				outLine = line
+				# Calculate the VAF of these alleles
+				altMolecules = 0
+				for allele in passingAltAlleles:
+					altMolecules += float(infoFields["MC"][baseToIndex[allele]])
+				totalMolecules = sum(float(infoFields["MC"][x]) for x in range(0, 4))
+				vaf = altMolecules / totalMolecules
+				outInfo = ";".join([infoCol, "VAF=" + str(vaf)])
+				outLine = line.replace(infoCol, outInfo)
 				origAltAlleles = line.split()[4]
 				newAltAlleles = ",".join(passingAltAlleles)
 				outLine = outLine.replace(origAltAlleles, newAltAlleles)

--- a/ProDuSe/filter_produse.py
+++ b/ProDuSe/filter_produse.py
@@ -217,7 +217,7 @@ def runFilter(vcfFile, thresholds, outFile, strandBiasThresh=0.05, allow_single=
 				for altAllele in altAlleles:
 
 					# Throw ignore alleles with significant strand bias
-					if infoFields["StrBiasP"][baseToIndex[altAllele]] <= strandBiasThresh:
+					if float(infoFields["StrBiasP"][baseToIndex[altAllele]]) <= strandBiasThresh:
 						continue
 
 					altMolecules = float(infoFields[molecule][baseToIndex[altAllele]])
@@ -231,7 +231,7 @@ def runFilter(vcfFile, thresholds, outFile, strandBiasThresh=0.05, allow_single=
 						if "n" in molecule or "N" in molecule:
 							if altAllele not in passingNegAlleles:
 								passingNegAlleles.append(altAllele)
-				if not supportsVariant and sum(int(infoFields[molecule][baseToIndex[x]]) for x in range(0, 4)) > threshold * 2:
+				if not supportsVariant and sum(int(infoFields[molecule][x]) for x in range(0, 4)) > threshold * 2:
 					# Do not strike if the same molecule class has already been given a strike
 					if molecule == "DpN" and "DPn" in strikes:
 						continue

--- a/ProDuSe/filter_produse.py
+++ b/ProDuSe/filter_produse.py
@@ -196,6 +196,10 @@ def filterVariant(refAllele, altAllele, desc, minVaf, minDuplex, minPosStrand, m
 		vaf: Variant allele fraction of the variant, if it passes filters. If it fails filters, 'None' is returned
 
 	"""
+
+	if refAllele == "N":
+		return None, None
+
 	nucToIndex = {"A":0, "C":1, "G":2, "T":3}
 	indexToNuc = {0:"A", 1:"C", 2:"G", 3:"T"}
 	refIndex = nucToIndex[refAllele]

--- a/ProDuSe/position.py
+++ b/ProDuSe/position.py
@@ -177,6 +177,7 @@ class PosCollection:
         self.variant_status = None
         self.bases = {}
         self.duplex_bases = []
+        self.weak_quality = []
         self.good_singleton_bases = []
         self.bad_singleton_bases = []
         self.good_duplex_bases = []
@@ -223,9 +224,11 @@ class PosCollection:
 
                 elif not passes_filter and is_positive:
                     column = "Sp"
+                    self.weak_quality.append(self.bases[duplex_id][0].qual)
 
                 else:
                     column = "Sn"
+                    self.weak_quality.append(self.bases[duplex_id][0].qual)
 
                 self.base_array[column][self.bases[duplex_id][0].base] += 1
                 if passes_filter and is_positive_strand:
@@ -308,6 +311,7 @@ class PosCollection:
                           #  print self.bases[duplex_id][0].qname.qname
                            # print self.bases[duplex_id][1].qname.qname
                         column = "Dpn"
+                        self.weak_quality.append(self.bases[duplex_id][0].qual)
 
                     self.base_array[column][self.bases[duplex_id][0].base] += 1
                     self.pos_counts[self.bases[duplex_id][0].base] += 1

--- a/ProDuSe/position.py
+++ b/ProDuSe/position.py
@@ -357,7 +357,12 @@ class PosCollection:
         for categ in categs:
             counts = sum(self.base_array[categ][base] for base in self.alt)
             molecule_counts = counts + sum(self.base_array[categ][base] for base in refBases)
-            molecVAF = float(counts)/float(molecule_counts)
+            # If there are no molecules of this type at this locus, that is informative
+            # Set the VAF to 0
+            if molecule_counts == 0:
+                molecVAF = 0
+            else:
+                molecVAF = float(counts) / float(molecule_counts)
             pos_info += str(molecVAF) + "\t"
             total_molecules += molecule_counts
 

--- a/ProDuSe/position.py
+++ b/ProDuSe/position.py
@@ -338,7 +338,7 @@ class PosCollection:
         Args:
             outFile: An open file object, which the header line is written to
         """
-        outFile.write("#TotalMolec\tDPN\tDPn\tDpN\tDpn\tSP\tSp\tSN\tSn\n")
+        outFile.write("#TotalMol\tDPN\tDPn\tDpN\tDpn\tSP\tSp\tSN\tSn\n")
 
     def position_stats(self, outFile):
         """

--- a/ProDuSe/position.py
+++ b/ProDuSe/position.py
@@ -357,7 +357,7 @@ class PosCollection:
             pos_info += str(counts) + "\t"
             molecule_counts += counts
 
-        pos_info = str(molecule_counts) + "\t" + pos_info[:-2] + "\n"
+        pos_info = str(molecule_counts) + "\t" + pos_info[:-1] + "\n"
         outFile.write(pos_info)
 
     def is_variant(self, min_alt_vaf, min_molecule_count, enforce_dual_strand, mutant_molecules):

--- a/ProDuSe/position.py
+++ b/ProDuSe/position.py
@@ -338,11 +338,12 @@ class PosCollection:
         Args:
             outFile: An open file object, which the header line is written to
         """
+        outFile.write("##Alternate allele(s) molecule counts for each locus\n")
         outFile.write("#TotalMol\tDPN\tDPn\tDpN\tDpn\tSP\tSp\tSN\tSn\n")
 
     def position_stats(self, outFile):
         """
-        Prints out molecule count information at this locus
+        Prints out alt molecule count information at this locus
 
         Args:
             outFile: An open file object, which the molecule counts are written to
@@ -350,12 +351,13 @@ class PosCollection:
         pos_info = ""
         # Calculates overall molecule abundance at this position (representing depth)
         categs = ["DPN", "DPn", "DpN", "Dpn", "SP", "Sp", "SN", "Sn"]
-        bases = ["A", "C", "G", "T"]
         molecule_counts = 0
+        allBases = ["A", "C", "G", "T"]
+        refBases = list(x for x in allBases if x not in self.alt)
         for categ in categs:
-            counts = sum(self.base_array[categ][base] for base in bases)
+            counts = sum(self.base_array[categ][base] for base in self.alt)
             pos_info += str(counts) + "\t"
-            molecule_counts += counts
+            molecule_counts += counts + sum(self.base_array[categ][base] for base in refBases)
 
         pos_info = str(molecule_counts) + "\t" + pos_info[:-1] + "\n"
         outFile.write(pos_info)

--- a/ProDuSe/position.py
+++ b/ProDuSe/position.py
@@ -351,15 +351,17 @@ class PosCollection:
         pos_info = ""
         # Calculates overall molecule abundance at this position (representing depth)
         categs = ["DPN", "DPn", "DpN", "Dpn", "SP", "Sp", "SN", "Sn"]
-        molecule_counts = 0
+        total_molecules = 0
         allBases = ["A", "C", "G", "T"]
         refBases = list(x for x in allBases if x not in self.alt)
         for categ in categs:
             counts = sum(self.base_array[categ][base] for base in self.alt)
-            pos_info += str(counts) + "\t"
-            molecule_counts += counts + sum(self.base_array[categ][base] for base in refBases)
+            molecule_counts = counts + sum(self.base_array[categ][base] for base in refBases)
+            molecVAF = float(counts)/float(molecule_counts)
+            pos_info += str(molecVAF) + "\t"
+            total_molecules += molecule_counts
 
-        pos_info = str(molecule_counts) + "\t" + pos_info[:-1] + "\n"
+        pos_info = str(total_molecules) + "\t" + pos_info[:-1] + "\n"
         outFile.write(pos_info)
 
     def is_variant(self, min_alt_vaf, min_molecule_count, enforce_dual_strand, mutant_molecules):

--- a/ProDuSe/position.py
+++ b/ProDuSe/position.py
@@ -339,7 +339,7 @@ class PosCollection:
             outFile: An open file object, which the header line is written to
         """
         outFile.write("##Alternate allele(s) molecule counts for each locus\n")
-        outFile.write("#TotalMol\tDPN\tDPn\tDpN\tDpn\tSP\tSp\tSN\tSn\n")
+        outFile.write("#TotalMol\tDPN_TOTAL\tDPN_ALT\tDPn_TOTAL\tDPn_ALT\tDpN_TOTAL\tDpN_ALT\tDpn_TOTAL\tDpn_ALT\tSP_TOTAL\tSP_ALT\tSp_TOTAL\tSp_ALT\tSN_TOTAL\tSN_ALT\tSn_TOTAL\tSn_ALT\n")
 
     def position_stats(self, outFile):
         """
@@ -354,19 +354,21 @@ class PosCollection:
         total_molecules = 0
         allBases = ["A", "C", "G", "T"]
         refBases = list(x for x in allBases if x not in self.alt)
+        last = len(categs) - 1
+        i = 0
         for categ in categs:
+            # Count the number of alternate and total molecules of this type
             counts = sum(self.base_array[categ][base] for base in self.alt)
             molecule_counts = counts + sum(self.base_array[categ][base] for base in refBases)
-            # If there are no molecules of this type at this locus, that is informative
-            # Set the VAF to 0
-            if molecule_counts == 0:
-                molecVAF = 0
-            else:
-                molecVAF = float(counts) / float(molecule_counts)
-            pos_info += str(molecVAF) + "\t"
             total_molecules += molecule_counts
 
-        pos_info = str(total_molecules) + "\t" + pos_info[:-1] + "\n"
+            if i == last:
+                pos_info += str(molecule_counts) + "\t" + str(counts)
+            else:
+                pos_info += str(molecule_counts) + "\t" + str(counts) + "\t"
+            i += 1
+
+        pos_info = str(total_molecules) + "\t" + pos_info + "\n"
         outFile.write(pos_info)
 
     def is_variant(self, min_alt_vaf, min_molecule_count, enforce_dual_strand, mutant_molecules):

--- a/ProDuSe/snv.py
+++ b/ProDuSe/snv.py
@@ -224,6 +224,7 @@ def main(args=None):
 
     counter = 1
     first = True
+    first_molec = True
     for pos in posCollection:
 
         pos.calc_base_stats(
@@ -233,6 +234,10 @@ def main(args=None):
 
         counter += 1
 
+        if first_molec:
+            pos.position_stats_header(statsFile)
+            first_molec = False
+        pos.position_stats(statsFile)
         if pos.is_variant(float(args.variant_allele_fraction_threshold), int(args.min_molecules), args.enforce_dual_strand, int(args.mutant_molecules)):
 
             if first:
@@ -240,10 +245,8 @@ def main(args=None):
                 fastaIndex = args.reference + ".fai"
                 contigs = parseContigs(fastaIndex)
                 pos.write_header(output, contigs, args.reference)
-                pos.position_stats_header(statsFile)
                 first = False
 
-            pos.position_stats(statsFile)
             pos.write_variant(output)
             # output.write(pos.coords() + "\n")
             # output.write(pos.ref + " > " + ''.join(pos.alt) + "\n")

--- a/ProDuSe/snv.py
+++ b/ProDuSe/snv.py
@@ -263,7 +263,7 @@ def main(args=None):
         #         output.write('\n');
 
     # else:
-        if counter % 100000 == 0:
+        if counter % 1000000 == 0:
                 sys.stdout.write("\t".join([printPrefix, time.strftime('%X'), "Positions Processed: %i\n" % (counter)]))
     #     for pos in posCollection:
 

--- a/ProDuSe/snv.py
+++ b/ProDuSe/snv.py
@@ -198,7 +198,7 @@ def main(args=None):
     printPrefix = "PRODUSE-SNV\t"
     sys.stdout.write("\t".join([printPrefix, time.strftime('%X'), "Starting...\n"]))
 
-    posCollection = position.PosCollectionCreate(bamfile, fastafile, filter_overlapping_reads=True, target_bed=targetbed, min_reads_per_uid=int(args.min_reads_per_uid), min_base_qual=int(args.min_qual))
+    posCollection = position.PosCollectionCreate(bamfile, fastafile, filter_overlapping_reads=True, target_bed=targetbed, min_reads_per_uid=int(args.min_reads_per_uid))
 
     output = None
     if not args.output == "-":
@@ -228,7 +228,8 @@ def main(args=None):
     for pos in posCollection:
 
         pos.calc_base_stats(
-            min_reads_per_uid=args.strong_supported_base_threshold
+            min_reads_per_uid=args.strong_supported_base_threshold,
+            min_base_qual=args.min_qual
             )
         # print "done %s  positions in for pos in posCollection at %s" % (m,pos.coords())
 

--- a/ProDuSe/snv.py
+++ b/ProDuSe/snv.py
@@ -259,7 +259,7 @@ def main(args=None):
         #         output.write('\n');
 
     # else:
-        if counter % 10000 == 0:
+        if counter % 100000 == 0:
                 sys.stdout.write("\t".join([printPrefix, time.strftime('%X'), "Positions Processed: %i\n" % (counter)]))
     #     for pos in posCollection:
 
@@ -280,7 +280,7 @@ def main(args=None):
 
     if not args.output == "-":
         output.close()
-    sys.stdout.write("\t".join([printPrefix, time.strftime('%X'), "Positions Processed: %i\n" % (counter)]))
+    sys.stdout.write("\t".join([printPrefix, time.strftime('%X'), "Positions Processed:%i\n" % (counter)]))
 
 
 if __name__ == '__main__':

--- a/ProDuSe/snv.py
+++ b/ProDuSe/snv.py
@@ -233,11 +233,6 @@ def main(args=None):
         # print "done %s  positions in for pos in posCollection at %s" % (m,pos.coords())
 
         counter += 1
-
-        if first_molec:
-            pos.position_stats_header(statsFile)
-            first_molec = False
-        pos.position_stats(statsFile)
         if pos.is_variant(float(args.variant_allele_fraction_threshold), int(args.min_molecules), args.enforce_dual_strand, int(args.mutant_molecules)):
 
             if first:
@@ -251,6 +246,11 @@ def main(args=None):
             # output.write(pos.coords() + "\n")
             # output.write(pos.ref + " > " + ''.join(pos.alt) + "\n")
             # output.write(str(pos))
+
+        if first_molec:
+            pos.position_stats_header(statsFile)
+            first_molec = False
+        pos.position_stats(statsFile)
 
         # if pos.coords2() in targetbed:
 

--- a/etc/produse_config.ini
+++ b/etc/produse_config.ini
@@ -24,3 +24,4 @@ adapter_sequence = NNNWSMRWSYWKMWWT
 adapter_position = 0001111111111110
 max_mismatch = 3
 
+[filter_produse]


### PR DESCRIPTION
ProDuSe variants called by snv.py are filtered based upon the following characteristics:
1) Strand bias: Variants with significant strand bias are filtered out
2) Molecule counts: Each locus is examined to identify molecules with which support a variant. Molecules are examined from the strongest (DPN) to the weakest (Sn and Sp). If there are too few molecules of a given type at a locus, the next molecule type is examined without counting against the variant.
Molecule thresholds scale dynamically based upon the characteristics of the capture space. At higher depths, additional weaker bases will be required in order for a variant to pass filters
3) Quality filtering of weak bases (Sn, Sp, Dpn)
3) Minimum depth: Currently, no minimum depth is required to call a variant, but this option is availible
